### PR TITLE
Update Flashpaper registry

### DIFF
--- a/templates/FlashPaper.xml
+++ b/templates/FlashPaper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>FlashPaper</Name>
-  <Repository>andrewpaglusch/flashpaper</Repository>
+  <Repository>ghcr.io/andrewpaglusch/flashpaper</Repository>
   <Registry>https://hub.docker.com/r/andrewpaglusch/flashpaper</Registry>
   <Network>bridge</Network>
   <MyIP/>


### PR DESCRIPTION
I just noticed, that the docker hub image from flashpaper was pushed 2 years ago (https://hub.docker.com/r/andrewpaglusch/flashpaper/tags) and it says `The latest release of FlashPaper is available at ghcr.io/andrewpaglusch/flashpaper.` in the origin repository (https://github.com/AndrewPaglusch/FlashPaper#docker-recommended).

So, I created this PR to keep it up to date ;)